### PR TITLE
fix input processing for dict in python3

### DIFF
--- a/alluvial.py
+++ b/alluvial.py
@@ -73,10 +73,10 @@ class AlluvialTool:
         return self.input
 
     def read_input(self):
-        return {
-            dict: self.read_input_from_dict(),
-            list: self.read_input_from_list()
-         }[type(self.input)]
+        if type(self.input) == dict:
+            return self.read_input_from_dict()
+        else:
+            return self.read_input_from_list()
 
     def get_item_widths_dic(self):
         iwd = Counter()


### PR DESCRIPTION
for me with python3, using the code for Example 1 didn't work, because of an error in the read_input method. in particular,  self.read_input_from_list() was called already by the generation of the dict, even though this dict element was not used. 
I made a quick fix for this, using an if-else statement instead.