### PR TITLE
replaced matplotlib.cm with colormaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ plt.show()
 <pre><code>
 import alluvial
 import matplotlib.pyplot as plt
-import matplotlib.cm
+from matplotlib import colormaps 
 import numpy as np
 
 # Generating the input_data:
@@ -46,7 +46,7 @@ def rand_letter(num): return chr(ord('A')+int(num*np.random.rand()))
 input_data = [[rand_letter(15), rand_letter(5)*2] for _ in range(50)]
 
 # Plotting:
-cmap = matplotlib.cm.get_cmap('jet')
+cmap = colormaps['jet']
 ax = alluvial.plot(
     input_data,  alpha=0.4, color_side=1, rand_seed=seed, figsize=(7,5),
     disp_width=True, wdisp_sep=' '*2, cmap=cmap, fontname='Monospace',

--- a/alluvial.py
+++ b/alluvial.py
@@ -2,7 +2,7 @@ import numpy as np
 from collections import Counter, defaultdict, OrderedDict
 import matplotlib.pyplot as plt
 from matplotlib.patches import Polygon
-import matplotlib.cm
+from matplotlib import colormaps 
 import itertools
 
 
@@ -185,7 +185,7 @@ class AlluvialTool:
         lci = len(color_items)
         if rand_seed is not None:
             np.random.seed(rand_seed)
-        cmap = cmap if cmap is not None else matplotlib.cm.get_cmap('hsv', lci * 10 ** 3)
+        cmap = cmap if cmap is not None else colormaps['hsv']
         color_array = colors if colors is not None else [
             cmap(item) for ind, item in enumerate(np.random.rand(lci))]
         ind_dic = {item: ind for ind, item in enumerate(color_items)}

--- a/tests/test_alluvial.py
+++ b/tests/test_alluvial.py
@@ -21,7 +21,7 @@ def test_alluvial_general_example2():
     try:
         import alluvial
         import matplotlib.pyplot as plt
-        import matplotlib.cm
+        from matplotlib import colormaps 
         import numpy as np
 
         # Generating the input_data:
@@ -32,7 +32,7 @@ def test_alluvial_general_example2():
         input_data = [[rand_letter(15), rand_letter(5)*2] for _ in range(50)]
 
         # Plotting:
-        cmap = matplotlib.cm.get_cmap('jet')
+        cmap = colormaps['jet']
         ax = alluvial.plot(
             input_data,  alpha=0.4, color_side=1, rand_seed=seed, figsize=(7,5),
             disp_width=True, wdisp_sep=' '*2, cmap=cmap, fontname='Monospace',


### PR DESCRIPTION
Created in response to https://github.com/vinsburg/alluvial_diagram/issues/11 @yonMaor 

At first tried colormaps.get_cmap but that has not yet been implemented in python3.7
Ended setting up docker to test python3.7 and verify colormaps['jet'] works